### PR TITLE
change commands for systemd

### DIFF
--- a/content/common-issues/index.md
+++ b/content/common-issues/index.md
@@ -86,21 +86,25 @@ If you noticed that your Pwnagotchi isnt beeing recognized by Windows follow the
 
 ## Pwnagotchi's subnet clash with computer's subnet
 
-If your network is using `10.0.0.0/24` as the network address and this is clashing with Pwnagotchi's network address, you can change the IP address and network address of Pwnagotchi USB interface by using a different subnet. In order to do this, login to your pi via SSH and edit the file `/etc/network/interfaces.d/usb0-cfg` with your preferred editor and use the following config:
+If your network is using `10.0.0.0/24` as the network address and this is clashing with Pwnagotchi's network address, you can change the IP address and network address of Pwnagotchi USB interface by using a different subnet. In order to do this, login to your pi via SSH and do the following:
+run
+`sudo nano /etc/systemd/network/73-usb-net-by-mac.network`
+and paste in the following:
 
 ```
-allow-hotplug usb0
-iface usb0 inet static
-  address 192.168.0.2
-  netmask 255.255.255.0
-  network 192.168.0.0
-  broadcast 192.168.0.255
-  gateway 192.168.0.1
-  dns-nameservers 1.1.1.1
-  metric 20
-```
+[Match]
+Name=usb0
 
-Save the file and reboot your pwnagotchi. After it boots up, you should be able to access it by using the ip address `192.168.0.2` instead of `10.0.0.2`. **Remember to change also the configuration of your computer's interface by using the IP address `192.168.0.1`.**
+[Network]
+Address=192.168.0.2/24
+Gateway=192.168.0.1
+DHCP=no
+KeepConfiguration=no
+```
+and last but not least, run these two commands.
+`sudo systemctl enable systemd-networkd`
+`sudo reboot now`
+Your Pwnagotchi should reboot now and apply the new config. After it boots up, you should be able to access it by using the ip address `192.168.0.2` instead of `10.0.0.2`. **Remember to change also the configuration of your computer's interface by using the IP address `192.168.0.1`.**
 
 ## Pwnagotchi changes MAC address with every Boot (New network device)
 


### PR DESCRIPTION
The fixes to change the used subnet for usb0 were not valid for newer images that use systemd.
Now the fixes work again to set a custom subnet 